### PR TITLE
Store `extras` in struct

### DIFF
--- a/src/GetindexArrays.jl
+++ b/src/GetindexArrays.jl
@@ -2,18 +2,19 @@ module GetindexArrays
 
 export GetindexArray
 
-struct GetindexArray{T,N,F,Axs<:NTuple{N,AbstractUnitRange{Int}}} <: AbstractArray{T,N}
+struct GetindexArray{T,N,F,Axs<:NTuple{N,AbstractUnitRange{Int}},Ex} <: AbstractArray{T,N}
     getindex::F
     axes::Axs
+    extras::Ex     # captured data needed to implement `getindex`
 end
-GetindexArray{T}(getindex::F, axes) where {T,F} =
-    GetindexArray{T, length(axes), F, typeof(axes)}(getindex, axes)
-GetindexArray(getindex::F, axes) where F =
-    GetindexArray{Base._return_type(getindex, NTuple{length(axes), Int})}(getindex, axes)
+GetindexArray{T}(getindex::F, axes, extras=nothing) where {T,F} =
+    GetindexArray{T, length(axes), F, typeof(axes), typeof(extras)}(getindex, axes, extras)
+GetindexArray(getindex::F, axes, extras=nothing) where F =
+    GetindexArray{Base._return_type(getindex, Tuple{typeof(extras), NTuple{length(axes), Int}})}(getindex, axes, extras)
 
 Base.@propagate_inbounds function Base.getindex(A::GetindexArray{T,N}, i::Vararg{Int,N}) where {T,N}
     @boundscheck checkbounds(A, i...)
-    convert(T, A.getindex(i...))::T
+    convert(T, A.getindex(A.extras, i))::T
 end
 Base.size(A::GetindexArray) = map(length, A.axes)
 Base.axes(A::GetindexArray) = A.axes

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,7 +11,7 @@ end
 
 @testset "GetindexArrays.jl" begin
     # A purely computational array
-    A = GetindexArray((Base.OneTo(5), Base.OneTo(7))) do y, x
+    A = GetindexArray((Base.OneTo(5), Base.OneTo(7))) do _, (y, x)
         asin((x-1)^2/72 + (y-1)^2/32)
     end
     @test @inferred(A[1, 1]) == 0
@@ -24,11 +24,11 @@ end
     @test P[1, 2] == 2
     @test P[2, 1] == 3
     @test P[2, 2] == 4
-    A = GetindexArray(axes(P)) do idx...
+    A = GetindexArray(axes(P), P) do AA, idx
         # reverse both indexes
-        P[(size(P) .+ 1 .- idx)...]
+        AA[(size(AA) .+ 1 .- idx)...]
     end
-    @test A[1, 1] == 4
+    @test @inferred(A[1, 1]) == 4
     @test A[1, 2] == 3
     @test A[2, 1] == 2
     @test A[2, 2] == 1
@@ -36,21 +36,13 @@ end
     @test_throws BoundsError A[2, 3]
     @test @inferred(axes(A)) == axes(P)
 
-    # Same as above, but inferrably
-    makeA(P) = GetindexArray(axes(P)) do idx...
-        # reverse both indexes
-        P[(size(P) .+ 1 .- idx)...]
-    end
-    A = @inferred(makeA(P))
-    @test @inferred(A[1, 1]) == 4
-
     # Test that construction is inferred (@inferred can't handle `do` syntax)
     # on an example that mimics PermutedDimsArray
     P = rand(3, 2)
-    A = @inferred(GetindexArray{eltype(P)}((i1, i2)->P[i2, i1], reverse(axes(P))))
+    A = @inferred(GetindexArray{eltype(P)}((AA, (i1, i2))->AA[i2, i1], reverse(axes(P)), P))
     @test @inferred(size(A)) == (2, 3)
     @test @inferred(axes(A)) == (1:2, 1:3)
-    @test A[1, 1] == P[1, 1]
+    @test @inferred(A[1, 1]) == P[1, 1]
     @test A[2, 1] == P[1, 2]
     @test_throws BoundsError A[3, 1]
     @test A[1, 2] == P[2, 1]
@@ -60,8 +52,8 @@ end
     @test_throws BoundsError A[1, 4]
 
     P = rand(3, 5, 4)
-    A = GetindexArray((axes(P, 1), axes(P, 3))) do i1, i2
-        sum(view(P, i1, :, i2))
+    A = GetindexArray((axes(P, 1), axes(P, 3)), P) do AA, (i1, i2)
+        sum(view(AA, i1, :, i2))
     end
     @test size(A) == (3, 4)
     for i in eachindex(A)
@@ -69,9 +61,8 @@ end
     end
 
     # A much more complex example using traits, applying a coordinate transformation,
-    # mapping values, and local averaging. Also enforces inferrability.
-
-    function special_getindex(A::AbstractArray{T,N}, tforms, i::Vararg{Int,N}) where {T,N}
+    # mapping values, and local averaging.
+    function fancy_getindex((A, tforms), i)
         # Get the spatial slice and transformation for this time point
         tax, ti = timeaxis(A), i[timedim(A)]
         Aspatial = view(A, tax(ti))
@@ -92,17 +83,10 @@ end
         return sqrt(s/n)
     end
 
-    # Because tforms is captured, construct everything inside a function
-    function make_all(P, tforms)
-        # forced specialization
-        capture_getindex(i::Vararg{Int,N}) where {N} = special_getindex(P, tforms, i...)
-        A = @inferred(GetindexArray(capture_getindex, axes(P)))
-        return A
-    end
     tforms = [LinearMap(RotMatrix(θ)) for θ = 0:π/16:2π]
     P = zeros(8, 13, length(tforms))
     P[3:6, 4:9, :] .= 1
     P = AxisArray(OffsetArray(P, -3:4, -6:6, 1:length(tforms)), :y, :x, :time)
-    A = make_all(P, tforms)
+    A = @inferred(GetindexArray(fancy_getindex, axes(P), (P, tforms)))
     @test @inferred(A[0, 0, lastindex(tforms)]) === 1.0
 end


### PR DESCRIPTION
This alternative implementation makes it easier to construct arrays
where indexing depends on some additional data without needing to
fear non-constant globals.  This comes at the cost of needing to
provide an extra argument to the supplied `getindex` function.

It also passes the index as a tuple. This makes it more likely to be
automatically specialized than the `Vararg` would be.
